### PR TITLE
Avoid redundant iterator close in select

### DIFF
--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -1512,13 +1512,13 @@ decr(I) when is_integer(I) ->
 decr(infinity) ->
     infinity.
 
-traverse_continue(K, 0, Pfx, MS, _OldI, #sel{limit = Limit, ref = Ref} = Sel, AccKeys, Acc) ->
+traverse_continue(K, 0, Pfx, MS, _I, #sel{limit = Limit, ref = Ref} = Sel, AccKeys, Acc) ->
     {lists:reverse(Acc),
      fun() ->
 	     with_iterator(Ref,
-			   fun(I) ->
-                                   select_traverse(iterator_next(I, K),
-                                                   Limit, Pfx, MS, I, Sel,
+			   fun(NewI) ->
+                                   select_traverse(iterator_next(NewI, K),
+                                                   Limit, Pfx, MS, NewI, Sel,
                                                    AccKeys, [])
 			   end)
      end};

--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -1512,10 +1512,9 @@ decr(I) when is_integer(I) ->
 decr(infinity) ->
     infinity.
 
-traverse_continue(K, 0, Pfx, MS, OldI, #sel{limit = Limit, ref = Ref} = Sel, AccKeys, Acc) ->
+traverse_continue(K, 0, Pfx, MS, _OldI, #sel{limit = Limit, ref = Ref} = Sel, AccKeys, Acc) ->
     {lists:reverse(Acc),
      fun() ->
-	     catch ?leveldb:iterator_close(OldI),
 	     with_iterator(Ref,
 			   fun(I) ->
                                    select_traverse(iterator_next(I, K),


### PR DESCRIPTION
The iterator close in the select continuation is redundant, as the return from with_iterator will already have done that.  It's also harmful since it will fail and trigger the full exception handling machinery.

Rename the new iterator to NewI, and the current one from OldI to I, to match the other clause.