### PR TITLE
fix unwrapping of legacy select continuation objects

### DIFF
--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -759,7 +759,7 @@ select(Cont) ->
     %% older versions of mnesia_ext (before OTP 20).
     case Cont of
         {_, '$end_of_table'} -> '$end_of_table';
-        {_, Cont}            -> Cont();
+        {_, Cont1}           -> Cont1();
         '$end_of_table'      -> '$end_of_table';
         _                    -> Cont()
     end.


### PR DESCRIPTION
The code for wrapping select continuations from older OTP releases has a variable naming problem and as a result will never match.  Rename the nested Cont to fix the problem (c.f. get_sel_cont/1 in older versions of the backend).