### PR TITLE
Do not store record name

### DIFF
--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -913,8 +913,8 @@ handle_call({load, Alias, Tab, Type, LdbOpts}, _From,
             #st{type = Type, alias = Alias, tab = Tab} = St) ->
     {ok, Ref, Ets} = do_load_table(Tab, LdbOpts),
     {reply, ok, St#st{ref = Ref, ets = Ets}};
-handle_call(get_ref, _From, #st{ref = Ref, type = Type} = St) ->
-    {reply, {Ref, Type}, St};
+handle_call(get_ref, _From, #st{ref = Ref, type = Type, record_name = RecName} = St) ->
+    {reply, {Ref, Type, RecName}, St};
 handle_call({write_info, Key, Value}, _From, #st{} = St) ->
     _ = write_info_(Key, Value, St),
     {reply, ok, St};

--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -633,11 +633,12 @@ fixtable(_Alias, _Tab, _Bool) ->
     true.
 
 %% To save storage space, we avoid storing the key twice. We replace the key
-%% in the record with []. It has to be put back in lookup/3.
+%% in the record with []. It has to be put back in lookup/3.  Similarly we
+%% avoid storing the record name.
 insert(Alias, Tab, Obj) ->
     Pos = keypos(Tab),
     EncKey = encode_key(element(Pos, Obj)),
-    EncVal = encode_val(setelement(Pos, Obj, [])),
+    EncVal = encode_val(set_record(Pos, Obj, [], [])),
     call(Alias, Tab, {insert, EncKey, EncVal}).
 
 last(Alias, Tab) ->

--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -647,7 +647,7 @@ i_last(I) ->
 %% into the found record.
 lookup(Alias, Tab, Key) ->
     Enc = encode_key(Key),
-    {Ref, Type} = call(Alias, Tab, get_ref),
+    {Ref, Type} = get_ref(Alias, Tab),
     case Type of
 	bag -> lookup_bag(Ref, Key, Enc, keypos(Tab));
 	_ ->
@@ -672,7 +672,7 @@ lookup_bag_(Sz, Enc, {ok, Enc, _}, K, I, KP) ->
 lookup_bag_(Sz, Enc, Res, K, I, KP) ->
     case Res of
 	{ok, <<Enc:Sz/binary, _:?BAG_CNT>>, V} ->
-	    [setelement(KP, decode_val(V), K)|
+	    [setelement(KP, decode_val(V), K) |
 	     lookup_bag_(Sz, Enc, ?leveldb:iterator_move(I, next), K, I, KP)];
 	_ ->
 	    []
@@ -725,7 +725,7 @@ i_next_loop(_, _I, _Key) ->
     '$end_of_table'.
 
 prev(Alias, Tab, Key0) ->
-    {Ref, _Type} = call(Alias, Tab, get_ref),
+    {Ref, _Type} = get_ref(Alias, Tab),
     Key = encode_key(Key0),
     with_keys_only_iterator(Ref, fun(I) -> i_prev(I, Key) end).
 


### PR DESCRIPTION
Mnesia requires all tuples in a table to be of the same record type, i.e. be tuples of the same arity with the same atom in the first position.

Storing the record name is redundant as it's a function of the schema for the table. Therefore, replace the record name with [] when storing records, and insert it when reading records.

This is similar to what mnesia_eleveldb already does for the key, since leveldb stores <key,value> pairs rather than tuples-with-a-key.

(Note to Klarna reviewers: this is identical to our internal development for this feature, but without live upgrade compat steps, and without references to internal tickets.)
