### PR TITLE
handle empty MatchSpec in select

### DIFF
--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -785,6 +785,8 @@ select(Alias, Tab, Ms) ->
             '$end_of_table'
     end.
 
+select(_Alias, _Tab, _Ms = [], _Limit) ->
+    {[], '$end_of_table'};
 select(Alias, Tab, Ms, Limit) when Limit==infinity; is_integer(Limit) ->
     {Ref, Type, RecName} = get_ref(Alias, Tab),
     do_select(Ref, Tab, Type, Ms, Limit, RecName).


### PR DESCRIPTION
Trying to select on a mnesia_eleveldb table with an empty MatchSpec currently fails with a badarg exception. Doing the same on other table types works as expected, returning an empty list as result.

The crash happens because the MatchSpec is passed to ets:match_spec_compile/1, and that one does not tolerate empty MatchSpecs.

Add a check to prevent this valid use case from failing.