### PR TITLE
Remove get stacktrace call

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ mnesia tables.
 
 ## Prerequisites
 - eleveldb (https://github.com/basho/eleveldb)
-- Erlang/OTP 19.0 or newer (https://github.com/erlang/otp)
+- Erlang/OTP 21.0 or newer (https://github.com/erlang/otp)
 
 ## Getting started
 

--- a/src/mnesia_eleveldb.erl
+++ b/src/mnesia_eleveldb.erl
@@ -445,8 +445,8 @@ close_table_(Alias, Tab) ->
 pp_stack() ->
     Trace = try throw(true)
             catch
-                _:_ ->
-                    case erlang:get_stacktrace() of
+                _:_:StackTrace ->
+                    case StackTrace of
                         [_|T] -> T;
                         [] -> []
                     end


### PR DESCRIPTION
Needed for OTP-23.
This means we require OTP-21 or newer.  Older versions (i.e., 19 and 20) could still be supported with some work and ugly code, but I don't want to do that unless absolutely necessary.